### PR TITLE
Getting PHP-Twig working with TextMate

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>contactEmailRot13</key>


### PR DESCRIPTION
Just tried to get this working on a Mac with TextMate, and the info.plist file needed a couple of updates to be accepted.  I see that the DOCTYPE said "Apple Computer" before it became just "Apple"; not sure why that was changed, but TextMate definitely didn't like it.  :)
