### PR TITLE
Twig Monokai Light Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ To aid theming, here's a list of what each Twig element is scoped to.
                 End:   punctuation.section.array.end.twig
                 
     Strings:
-        Single:        string.quoted.singled.twig
-        Double:        string.quoted.doubled.twig
+        Single:        string.quoted.single.twig
+        Double:        string.quoted.double.twig
     Arrays:            meta.array.twig
         Accessor:
             Begin:     punctuation.section.array.begin.twig


### PR DESCRIPTION
This pull request includes:
- A typo fixed on the README:
  `string.quoted.single.twig` -> `string.quoted.singled.twig`
  `string.quoted.double.twig` -> `string.quoted.doubled.twig`
- Monokai Light theme for Twig.
