### PR TITLE
Add file extension (.html.twig)

### DIFF
--- a/Syntaxes/HTML (Twig).tmLanguage
+++ b/Syntaxes/HTML (Twig).tmLanguage
@@ -5,6 +5,7 @@
     <key>fileTypes</key>
     <array>
         <string>twig</string>
+        <string>html.twig</string>
     </array>
     <key>firstLineMatch</key>
     <string>&lt;!DOCTYPE|&lt;(?i:html)|&lt;\?(?i:php)|\{\{|\{%|\{#</string>


### PR DESCRIPTION
Hello! I added recognition of popular twig file extension - .html.twig, is is used in Symfony2 framework by default. I this it will be useful )
