### PR TITLE
Added keyword “verbatim”

### DIFF
--- a/Syntaxes/HTML (Twig).tmLanguage
+++ b/Syntaxes/HTML (Twig).tmLanguage
@@ -14,14 +14,14 @@
         (&lt;(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|li|form|dl)\b.*?&gt;
         |&lt;!--(?!.*--\s*&gt;)
         |^&lt;!--\ \#tminclude\ (?&gt;.*?--&gt;)$
-        |\{%\s+(if|for|spaceless|raw|autoescape|macro|)
+        |\{%\s+(if|for|spaceless|raw|verbatim|autoescape|macro|)
         )</string>
     <key>foldingStopMarker</key>
     <string>(?x)
         (&lt;/(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|li|form|dl)&gt;
         |^(?!.*?&lt;!--).*?--\s*&gt;
         |^&lt;!--\ end\ tminclude\ --&gt;$
-        |\{%\s+end(if|for|spaceless|raw|autoescape|macro|)
+        |\{%\s+end(if|for|spaceless|raw|verbatim|autoescape|macro|)
         )</string>
     <key>keyEquivalent</key>
     <string>^~T</string>
@@ -1389,7 +1389,7 @@
         <key>twig-keywords</key>
         <dict>
             <key>match</key>
-            <string>(?&lt;=\s)((?:end)?(?:autoescape|block|embed|filter|for|if|macro|raw|sandbox|set|spaceless)|as|do|else|elseif|extends|flush|from|ignore missing|import|include|only|use|with)(?=\s)</string>
+            <string>(?&lt;=\s)((?:end)?(?:autoescape|block|embed|filter|for|if|macro|raw|verbatim|sandbox|set|spaceless)|as|do|else|elseif|extends|flush|from|ignore missing|import|include|only|use|with)(?=\s)</string>
             <key>name</key>
             <string>keyword.control.twig</string>
         </dict>


### PR DESCRIPTION
New keyword “verbatim” in version 1.12 – it was named “raw” before.
