### PR TITLE
Make tag-block.tmSnippet smarter

### DIFF
--- a/Snippets/tag-block.tmSnippet
+++ b/Snippets/tag-block.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>content</key>
-    <string>{% $1 %}$0</string>
+    <string>{% $1$2 %}$0{% end$1 %}</string>
     <key>name</key>
     <string>{% ... %}</string>
     <key>scope</key>


### PR DESCRIPTION
This will automatically write the closing tag and allow to augment the opening tag with further statements by simply tabbing through the three positions tagname (open/close), tag parameters, tag content.
