### PR TITLE
Added mention of the syntax name, since it's not obvious.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To install this bundle in Sublime Text, a few extra steps are required.
 2. In the directory that was just opened, create a new directory `PHP-Twig/`.
 3. Move the contents of the `Preferences/`, `Snippets/`, and `Syntaxes/` directories of this repo into the directory you just created.
 4. Restart Sublime Text.
+5. The syntax is called HTML (Twig).
 
 ### TextMate
 


### PR DESCRIPTION
I installed it 3 times before I figured out that it's called neither Twig nor PHP. For people who have 50+ syntax options installed, it's good to know that it's actually called HTML (Twig). Cheers!
