### PR TITLE
Fix: if-...-else-...-endif block indentation

### DIFF
--- a/Preferences/Indentation.tmPreferences
+++ b/Preferences/Indentation.tmPreferences
@@ -19,7 +19,7 @@
             |\})
         )|
         (?:
-            ^\s*\{%-?\send(?:autoescape|block|embed|filter|for|if|macro|raw|sandbox|set|spaceless|trans|verbatim)(?:(?!%\}).)*\s-?%\}
+            ^\s*\{%-?\s(end(?:autoescape|block|embed|filter|for|if|macro|raw|sandbox|set|spaceless|trans|verbatim)|(else))(?:(?!%\}).)*\s-?%\}
         )
         </string>
         <key>increaseIndentPattern</key>
@@ -33,7 +33,7 @@
             |\{[^}"']*$
         )|
         (?:
-            ^\s*\{%-?\s(autoescape|block|embed|filter|for|if|macro|raw|sandbox|set|spaceless|trans|verbatim)(?:(?!%\}).)*\s-?%\}(?!.*\{%-?\send\1)
+            ^\s*\{%-?\s(autoescape|block|embed|filter|for|if|else|macro|raw|sandbox|set|spaceless|trans|verbatim)(?:(?!%\}).)*\s-?%\}(?!.*\{%-?\send\1)
         )
         </string>
         <key>bracketIndentNextLinePattern</key>


### PR DESCRIPTION
Original behavior:

``` twig
{% if true %}
    <div>Toto</div>
    {% else %}    
    <div>Titi</div>
{% endif %}
```

With the fix:

``` twig
{% if true %}
    <div>Toto</div>
{% else %}    
    <div>Titi</div>
{% endif %}
```
