### PR TITLE
Add "twig.html" extension support. 

### DIFF
--- a/Syntaxes/HTML (Twig).tmLanguage
+++ b/Syntaxes/HTML (Twig).tmLanguage
@@ -6,6 +6,7 @@
     <array>
         <string>twig</string>
         <string>html.twig</string>
+        <string>twig.html</string>
     </array>
     <key>keyEquivalent</key>
     <string>^~T</string>


### PR DESCRIPTION
Easy integration with multiple IDE because this extension allows using default html highlight (with no Twig highlight) in others IDE or missing this plugin. 
