### PR TITLE
Match new HTML scopes for doctype/processing tags

### DIFF
--- a/Syntaxes/HTML (Twig).tmLanguage
+++ b/Syntaxes/HTML (Twig).tmLanguage
@@ -77,13 +77,13 @@
                 <key>2</key>
                 <dict>
                     <key>name</key>
-                    <string>entity.name.tag.xml.html</string>
+                    <string>entity.name.tag.html</string>
                 </dict>
             </dict>
             <key>end</key>
             <string>(\?&gt;)</string>
             <key>name</key>
-            <string>meta.tag.preprocessor.xml.html</string>
+            <string>meta.tag.metadata.processing.xml.html</string>
             <key>patterns</key>
             <array>
                 <dict>
@@ -143,7 +143,7 @@
             <key>end</key>
             <string>&gt;</string>
             <key>name</key>
-            <string>meta.tag.sgml.html</string>
+            <string>meta.tag.metadata.doctype.html</string>
             <key>patterns</key>
             <array>
                 <dict>
@@ -154,13 +154,11 @@
                         <key>1</key>
                         <dict>
                             <key>name</key>
-                            <string>entity.name.tag.doctype.html</string>
+                            <string>entity.name.tag.html</string>
                         </dict>
                     </dict>
                     <key>end</key>
                     <string>(?=&gt;)</string>
-                    <key>name</key>
-                    <string>meta.tag.sgml.doctype.html</string>
                     <key>patterns</key>
                     <array>
                         <dict>


### PR DESCRIPTION
Other tags are out of line now but this should probably be corrected by reducing the current duplication to a minimum.

(This brings the scopes in line with some changes that were just made the the HTML grammar and various themes.)